### PR TITLE
Ignore `v` prefix from tag name when updating Homebrew formula

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 We require node `v12.x`. Please make sure you are running the right version.
 
 ```sh
-npm run install
+npm install
 ```
 
 ## Develop

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: 'The Homebrew Tap repo (format: org/repo_name)'
     required: true
   srcRepo:
-    description: 'The repo of the source. Defaults to currenct context repo'
+    description: 'The repo of the source. Defaults to current context repo'
     required: true
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -40232,7 +40232,7 @@ function run() {
             console.log("Preparing formula");
             // note: this excludes pre-releases
             const latestRelease = yield octokit.request(`GET /repos/${srcRepo}/releases/latest`);
-            const version = latestRelease.data.tag_name;
+            const version = utils_1.getVersionFromTag(latestRelease.data.tag_name);
             const releaseId = latestRelease.data.id;
             const assets = yield octokit.request(`GET /repos/${srcRepo}/releases/${releaseId}/assets`);
             const tarballUrl = lodash_1.find(assets.data, a => a.name.includes("macos")).browser_download_url;
@@ -40302,7 +40302,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getUrlChecksum = void 0;
+exports.getVersionFromTag = exports.getUrlChecksum = void 0;
 const axios_1 = __importDefault(__webpack_require__(6545));
 const crypto_1 = __webpack_require__(6417);
 function getUrlChecksum(url, algorithm = "sha256") {
@@ -40325,6 +40325,15 @@ function getUrlChecksum(url, algorithm = "sha256") {
     });
 }
 exports.getUrlChecksum = getUrlChecksum;
+function getVersionFromTag(tag_name) {
+    if (tag_name.startsWith("v")) {
+        return tag_name.substring(1);
+    }
+    else {
+        return tag_name;
+    }
+}
+exports.getVersionFromTag = getVersionFromTag;
 
 
 /***/ }),
@@ -40341,7 +40350,7 @@ module.exports = eval("require")("encoding");
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse("{\"_args\":[[\"axios@0.20.0\",\"/Users/ths/src/update-homebrew-action\"]],\"_from\":\"axios@0.20.0\",\"_id\":\"axios@0.20.0\",\"_inBundle\":false,\"_integrity\":\"sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==\",\"_location\":\"/axios\",\"_phantomChildren\":{},\"_requested\":{\"type\":\"version\",\"registry\":true,\"raw\":\"axios@0.20.0\",\"name\":\"axios\",\"escapedName\":\"axios\",\"rawSpec\":\"0.20.0\",\"saveSpec\":null,\"fetchSpec\":\"0.20.0\"},\"_requiredBy\":[\"/\"],\"_resolved\":\"https://registry.npmjs.org/axios/-/axios-0.20.0.tgz\",\"_spec\":\"0.20.0\",\"_where\":\"/Users/ths/src/update-homebrew-action\",\"author\":{\"name\":\"Matt Zabriskie\"},\"browser\":{\"./lib/adapters/http.js\":\"./lib/adapters/xhr.js\"},\"bugs\":{\"url\":\"https://github.com/axios/axios/issues\"},\"bundlesize\":[{\"path\":\"./dist/axios.min.js\",\"threshold\":\"5kB\"}],\"dependencies\":{\"follow-redirects\":\"^1.10.0\"},\"description\":\"Promise based HTTP client for the browser and node.js\",\"devDependencies\":{\"bundlesize\":\"^0.17.0\",\"coveralls\":\"^3.0.0\",\"es6-promise\":\"^4.2.4\",\"grunt\":\"^1.0.2\",\"grunt-banner\":\"^0.6.0\",\"grunt-cli\":\"^1.2.0\",\"grunt-contrib-clean\":\"^1.1.0\",\"grunt-contrib-watch\":\"^1.0.0\",\"grunt-eslint\":\"^20.1.0\",\"grunt-karma\":\"^2.0.0\",\"grunt-mocha-test\":\"^0.13.3\",\"grunt-ts\":\"^6.0.0-beta.19\",\"grunt-webpack\":\"^1.0.18\",\"istanbul-instrumenter-loader\":\"^1.0.0\",\"jasmine-core\":\"^2.4.1\",\"karma\":\"^1.3.0\",\"karma-chrome-launcher\":\"^2.2.0\",\"karma-coverage\":\"^1.1.1\",\"karma-firefox-launcher\":\"^1.1.0\",\"karma-jasmine\":\"^1.1.1\",\"karma-jasmine-ajax\":\"^0.1.13\",\"karma-opera-launcher\":\"^1.0.0\",\"karma-safari-launcher\":\"^1.0.0\",\"karma-sauce-launcher\":\"^1.2.0\",\"karma-sinon\":\"^1.0.5\",\"karma-sourcemap-loader\":\"^0.3.7\",\"karma-webpack\":\"^1.7.0\",\"load-grunt-tasks\":\"^3.5.2\",\"minimist\":\"^1.2.0\",\"mocha\":\"^5.2.0\",\"sinon\":\"^4.5.0\",\"typescript\":\"^2.8.1\",\"url-search-params\":\"^0.10.0\",\"webpack\":\"^1.13.1\",\"webpack-dev-server\":\"^1.14.1\"},\"homepage\":\"https://github.com/axios/axios\",\"jsdelivr\":\"dist/axios.min.js\",\"keywords\":[\"xhr\",\"http\",\"ajax\",\"promise\",\"node\"],\"license\":\"MIT\",\"main\":\"index.js\",\"name\":\"axios\",\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/axios/axios.git\"},\"scripts\":{\"build\":\"NODE_ENV=production grunt build\",\"coveralls\":\"cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js\",\"examples\":\"node ./examples/server.js\",\"fix\":\"eslint --fix lib/**/*.js\",\"postversion\":\"git push && git push --tags\",\"preversion\":\"npm test\",\"start\":\"node ./sandbox/server.js\",\"test\":\"grunt test && bundlesize\",\"version\":\"npm run build && grunt version && git add -A dist && git add CHANGELOG.md bower.json package.json\"},\"typings\":\"./index.d.ts\",\"unpkg\":\"dist/axios.min.js\",\"version\":\"0.20.0\"}");
+module.exports = JSON.parse("{\"_args\":[[\"axios@0.20.0\",\"/Users/manojkarthick/code/forks/update-homebrew-action\"]],\"_from\":\"axios@0.20.0\",\"_id\":\"axios@0.20.0\",\"_inBundle\":false,\"_integrity\":\"sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==\",\"_location\":\"/axios\",\"_phantomChildren\":{},\"_requested\":{\"type\":\"version\",\"registry\":true,\"raw\":\"axios@0.20.0\",\"name\":\"axios\",\"escapedName\":\"axios\",\"rawSpec\":\"0.20.0\",\"saveSpec\":null,\"fetchSpec\":\"0.20.0\"},\"_requiredBy\":[\"/\"],\"_resolved\":\"https://registry.npmjs.org/axios/-/axios-0.20.0.tgz\",\"_spec\":\"0.20.0\",\"_where\":\"/Users/manojkarthick/code/forks/update-homebrew-action\",\"author\":{\"name\":\"Matt Zabriskie\"},\"browser\":{\"./lib/adapters/http.js\":\"./lib/adapters/xhr.js\"},\"bugs\":{\"url\":\"https://github.com/axios/axios/issues\"},\"bundlesize\":[{\"path\":\"./dist/axios.min.js\",\"threshold\":\"5kB\"}],\"dependencies\":{\"follow-redirects\":\"^1.10.0\"},\"description\":\"Promise based HTTP client for the browser and node.js\",\"devDependencies\":{\"bundlesize\":\"^0.17.0\",\"coveralls\":\"^3.0.0\",\"es6-promise\":\"^4.2.4\",\"grunt\":\"^1.0.2\",\"grunt-banner\":\"^0.6.0\",\"grunt-cli\":\"^1.2.0\",\"grunt-contrib-clean\":\"^1.1.0\",\"grunt-contrib-watch\":\"^1.0.0\",\"grunt-eslint\":\"^20.1.0\",\"grunt-karma\":\"^2.0.0\",\"grunt-mocha-test\":\"^0.13.3\",\"grunt-ts\":\"^6.0.0-beta.19\",\"grunt-webpack\":\"^1.0.18\",\"istanbul-instrumenter-loader\":\"^1.0.0\",\"jasmine-core\":\"^2.4.1\",\"karma\":\"^1.3.0\",\"karma-chrome-launcher\":\"^2.2.0\",\"karma-coverage\":\"^1.1.1\",\"karma-firefox-launcher\":\"^1.1.0\",\"karma-jasmine\":\"^1.1.1\",\"karma-jasmine-ajax\":\"^0.1.13\",\"karma-opera-launcher\":\"^1.0.0\",\"karma-safari-launcher\":\"^1.0.0\",\"karma-sauce-launcher\":\"^1.2.0\",\"karma-sinon\":\"^1.0.5\",\"karma-sourcemap-loader\":\"^0.3.7\",\"karma-webpack\":\"^1.7.0\",\"load-grunt-tasks\":\"^3.5.2\",\"minimist\":\"^1.2.0\",\"mocha\":\"^5.2.0\",\"sinon\":\"^4.5.0\",\"typescript\":\"^2.8.1\",\"url-search-params\":\"^0.10.0\",\"webpack\":\"^1.13.1\",\"webpack-dev-server\":\"^1.14.1\"},\"homepage\":\"https://github.com/axios/axios\",\"jsdelivr\":\"dist/axios.min.js\",\"keywords\":[\"xhr\",\"http\",\"ajax\",\"promise\",\"node\"],\"license\":\"MIT\",\"main\":\"index.js\",\"name\":\"axios\",\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/axios/axios.git\"},\"scripts\":{\"build\":\"NODE_ENV=production grunt build\",\"coveralls\":\"cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js\",\"examples\":\"node ./examples/server.js\",\"fix\":\"eslint --fix lib/**/*.js\",\"postversion\":\"git push && git push --tags\",\"preversion\":\"npm test\",\"start\":\"node ./sandbox/server.js\",\"test\":\"grunt test && bundlesize\",\"version\":\"npm run build && grunt version && git add -A dist && git add CHANGELOG.md bower.json package.json\"},\"typings\":\"./index.d.ts\",\"unpkg\":\"dist/axios.min.js\",\"version\":\"0.20.0\"}");
 
 /***/ }),
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import execa from "execa"
 import handlebars from "handlebars"
 import { writeFile, readFile, ensureDir, pathExists, remove } from "fs-extra"
 import { find } from "lodash"
-import { getUrlChecksum } from "./utils"
+import {getUrlChecksum, getVersionFromTag} from "./utils"
 
 const { GITHUB_WORKSPACE } = process.env
 
@@ -56,7 +56,7 @@ async function run() {
     // note: this excludes pre-releases
     const latestRelease = await octokit.request(`GET /repos/${srcRepo}/releases/latest`)
 
-    const version = latestRelease.data.tag_name
+    const version = getVersionFromTag(latestRelease.data.tag_name)
     const releaseId = latestRelease.data.id
 
     const assets = await octokit.request(`GET /repos/${srcRepo}/releases/${releaseId}/assets`)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,3 +30,11 @@ export async function getUrlChecksum(url: string, algorithm = "sha256") {
     response.data.on("error", reject)
   })
 }
+
+export function getVersionFromTag(tag_name: string) {
+  if (tag_name.startsWith("v")){
+    return tag_name.substring(1)
+  } else {
+    return tag_name
+  }
+}


### PR DESCRIPTION
Thanks for creating this awesome GitHub action!

**Description**

* If the tag name starts with `v`, then use the rest of the string as the version in the formula. Else, use as is.
* For example, `v0.1.0` becomes `0.1.0` in the tapped repo.
* It's common practice to name the tags `v${semantic_version}` when creating the GitHub release, but the first character needs to be removed when creating the tag and version for the Homebrew formula.

I don't have previous experience with JavaScript/TypeScript - so please provide feedback if it needs to be done differently!