### PR TITLE
Update tarballURL to use download.garden.io endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ import { resolve } from "path"
 import execa from "execa"
 import handlebars from "handlebars"
 import { writeFile, readFile, ensureDir, pathExists, remove } from "fs-extra"
-import { find } from "lodash"
 import { getUrlChecksum } from "./utils"
 
 const { GITHUB_WORKSPACE } = process.env

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,11 +57,8 @@ async function run() {
     const latestRelease = await octokit.request(`GET /repos/${srcRepo}/releases/latest`)
 
     const version = latestRelease.data.tag_name
-    const releaseId = latestRelease.data.id
 
-    const assets = await octokit.request(`GET /repos/${srcRepo}/releases/${releaseId}/assets`)
-
-    const tarballUrl = find(assets.data, a => a.name.includes("macos")).browser_download_url
+    const tarballUrl = `https://download.garden.io/core/${version}/garden-${version}-macos-amd64.tar.gz`
     const sha256 = await getUrlChecksum(tarballUrl, "sha256")
 
     const formula = template({


### PR DESCRIPTION
This PR is the replacement for https://github.com/garden-io/homebrew-garden/pull/7, where it was pointed out that Garden's homebrew formulae are generated here. This updates the tarballURL to use the new `download.garden.io` endpoint to match how release notes are being done for Garden Core. 